### PR TITLE
Contain player inside his castle and improve collision decetion

### DIFF
--- a/src/setup/map_builder.rs
+++ b/src/setup/map_builder.rs
@@ -5,7 +5,7 @@ pub const ARENA_WALL_THICKNESS: f32 = 5.0;
 pub const CASTLE_WALL_THICKNESS: f32 = 20.0;
 
 const CASTLE_WALL_LENGTH: f32 = ARENA_SIZE.0 / 4.0;
-const CASTLE_WALL_Y_TRANSLATION: f32 = ARENA_SIZE.1 / 3.0;
+pub const CASTLE_WALL_Y_TRANSLATION: f32 = ARENA_SIZE.1 / 3.0;
 
 pub fn spawn_arena_bounds(commands: &mut Commands) {
     let arena = Vec3::from(ARENA_SIZE);

--- a/src/setup/map_builder.rs
+++ b/src/setup/map_builder.rs
@@ -21,7 +21,11 @@ pub fn spawn_arena_bounds(commands: &mut Commands) {
     // right
     commands
         .spawn_bundle(SpriteBundle {
-            transform: Transform::from_translation(Vec3::new(arena.x / 2.0, 0.0, 0.0)),
+            transform: Transform::from_translation(Vec3::new(
+                arena.x / 2.0 + ARENA_WALL_THICKNESS / 2.0,
+                0.0,
+                0.0
+            )),
             sprite: sprite.clone(),
             ..default()
         })
@@ -30,7 +34,11 @@ pub fn spawn_arena_bounds(commands: &mut Commands) {
     // left
     commands
         .spawn_bundle(SpriteBundle {
-            transform: Transform::from_translation(Vec3::new(-arena.x / 2.0, 0.0, 0.0)),
+            transform: Transform::from_translation(Vec3::new(
+                -arena.x / 2.0 - ARENA_WALL_THICKNESS / 2.0,
+                0.0,
+                0.0
+            )),
             sprite,
             ..default()
         })

--- a/src/setup/player.rs
+++ b/src/setup/player.rs
@@ -1,6 +1,6 @@
 use crate::prelude::*;
 
-const PLAYER_SPEED: f32 = 400.0;
+const PLAYER_SPEED: f32 = 1200.0;
 const PLAYER_STARTING_TRANSLATION: (f32, f32, f32) =
     (0.0, -SCREEN_HEIGHT / 2.0 + ARENA_WALL_THICKNESS + 10.0, 0.0);
 
@@ -10,7 +10,7 @@ pub fn spawn_player(commands: &mut Commands) {
             transform: Transform::from_translation(Vec3::from(PLAYER_STARTING_TRANSLATION)),
             sprite: Sprite {
                 custom_size: Some(Vec2::from(PLAYER_SIZE)),
-                color: Color::YELLOW,
+                color: Color::BLUE,
                 ..default()
             },
             ..default()

--- a/src/systems/player.rs
+++ b/src/systems/player.rs
@@ -32,13 +32,13 @@ pub fn player_movement_system(
 
         translation.x = translation
             .x
-            .min(arena_size.x / 2.0 - ARENA_WALL_THICKNESS - player_one_side_size)
-            .max(-arena_size.x / 2.0 + ARENA_WALL_THICKNESS + player_one_side_size);
+            .min(arena_size.x / 2.0 - player_one_side_size)
+            .max(-arena_size.x / 2.0 + player_one_side_size);
 
         translation.y = translation
             .y
-            .min(arena_size.y / 2.0 - ARENA_WALL_THICKNESS - player_one_side_size)
-            .max(-arena_size.y / 2.0 + ARENA_WALL_THICKNESS + player_one_side_size);
+            .min(arena_size.y / 2.0 - CASTLE_WALL_THICKNESS / 2.0 - player_one_side_size)
+            .max(-arena_size.y / 2.0 + CASTLE_WALL_THICKNESS / 2.0 + player_one_side_size);
     }
 }
 

--- a/src/systems/player.rs
+++ b/src/systems/player.rs
@@ -37,7 +37,7 @@ pub fn player_movement_system(
 
         translation.y = translation
             .y
-            .min(arena_size.y / 2.0 - CASTLE_WALL_THICKNESS / 2.0 - player_one_side_size)
+            .min(-CASTLE_WALL_Y_TRANSLATION - ARENA_WALL_THICKNESS / 2.0 - player_one_side_size)
             .max(-arena_size.y / 2.0 + CASTLE_WALL_THICKNESS / 2.0 + player_one_side_size);
     }
 }

--- a/src/systems/player.rs
+++ b/src/systems/player.rs
@@ -1,7 +1,7 @@
 use crate::prelude::*;
 use bevy::input::mouse::MouseButtonInput;
 
-pub const PLAYER_SIZE: (f32, f32) = (16.0, 16.0);
+pub const PLAYER_SIZE: (f32, f32) = (24.0, 24.0);
 
 pub fn player_movement_system(
     keyboard_input: Res<Input<KeyCode>>,


### PR DESCRIPTION
1. Calculate player collision with arena bounds more accurately
2. Do not allow player to move out of his castle
3. Change player speed, size and color
4. Change the way arena bounds are calculated (Move them a bit further outside, so that they are not included in other calculations (the inside of arena will begin right at the edge of these bounds/walls))