### PR TITLE
Simplify coordinate calculations

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -18,8 +18,19 @@ mod prelude {
     pub use crate::systems::*;
 
     // todo handle resizing, different resolutions
-    pub const SCREEN_WIDTH: f32 = 1280.0;
-    pub const SCREEN_HEIGHT: f32 = 720.0;
+    pub struct ScreenSize {
+        pub width: f32,
+        pub width_half: f32,
+        pub height: f32,
+        pub height_half: f32,
+    }
+    pub const SCREEN_SIZE: ScreenSize = ScreenSize {
+        width: 1280.0,
+        width_half: 640.0,
+        height: 720.0,
+        height_half: 360.0,
+    };
+
     pub const MOVEMENT_TIME_STEP: f32 = 1.0 / 240.0;
 }
 
@@ -30,8 +41,8 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .insert_resource(WindowDescriptor {
             title: "Trajectorena".to_string(),
-            width: SCREEN_WIDTH,
-            height: SCREEN_HEIGHT,
+            width: SCREEN_SIZE.width,
+            height: SCREEN_SIZE.height,
             ..default()
         })
         .add_state(AppState::Menu)

--- a/src/setup/map_builder.rs
+++ b/src/setup/map_builder.rs
@@ -1,18 +1,35 @@
 use crate::prelude::*;
 
-pub const ARENA_SIZE: (f32, f32, f32) = (SCREEN_WIDTH / 2.0, SCREEN_HEIGHT, 0.0);
-pub const ARENA_WALL_THICKNESS: f32 = 5.0;
-pub const CASTLE_WALL_THICKNESS: f32 = 20.0;
+pub struct ArenaSize {
+    pub width: f32,
+    pub width_half: f32,
+    pub height: f32,
+    pub height_half: f32,
+    pub depth: f32,
+}
 
-const CASTLE_WALL_LENGTH: f32 = ARENA_SIZE.0 / 4.0;
-pub const CASTLE_WALL_Y_TRANSLATION: f32 = ARENA_SIZE.1 / 3.0;
+pub const ARENA_SIZE: ArenaSize = ArenaSize {
+    width: SCREEN_SIZE.width_half,
+    width_half: SCREEN_SIZE.width_half / 2.0,
+    height: SCREEN_SIZE.height,
+    height_half: SCREEN_SIZE.height / 2.0,
+    depth: 0.0,
+};
+
+pub const ARENA_WALL_THICKNESS: f32 = 5.0;
+pub const ARENA_WALL_THICKNESS_HALF: f32 = ARENA_WALL_THICKNESS / 2.0;
+pub const CASTLE_WALL_THICKNESS: f32 = 20.0;
+pub const CASTLE_WALL_THICKNESS_HALF: f32 = CASTLE_WALL_THICKNESS / 2.0;
+
+const CASTLE_WALL_LENGTH: f32 = ARENA_SIZE.width / 4.0;
+const CASTLE_WALL_LENGTH_HALF: f32 = CASTLE_WALL_LENGTH / 2.0;
+pub const CASTLE_WALL_Y_TRANSLATION: f32 = ARENA_SIZE.height / 3.0;
 
 pub fn spawn_arena_bounds(commands: &mut Commands) {
-    let arena = Vec3::from(ARENA_SIZE);
     let sprite = Sprite {
         custom_size: Some(Vec2::new(
             ARENA_WALL_THICKNESS,
-            arena.y + ARENA_WALL_THICKNESS,
+            ARENA_SIZE.height + ARENA_WALL_THICKNESS,
         )),
         color: Color::WHITE,
         ..default()
@@ -22,7 +39,7 @@ pub fn spawn_arena_bounds(commands: &mut Commands) {
     commands
         .spawn_bundle(SpriteBundle {
             transform: Transform::from_translation(Vec3::new(
-                arena.x / 2.0 + ARENA_WALL_THICKNESS / 2.0,
+                ARENA_SIZE.width_half + ARENA_WALL_THICKNESS_HALF,
                 0.0,
                 0.0
             )),
@@ -35,7 +52,7 @@ pub fn spawn_arena_bounds(commands: &mut Commands) {
     commands
         .spawn_bundle(SpriteBundle {
             transform: Transform::from_translation(Vec3::new(
-                -arena.x / 2.0 - ARENA_WALL_THICKNESS / 2.0,
+                -ARENA_SIZE.width_half - ARENA_WALL_THICKNESS_HALF,
                 0.0,
                 0.0
             )),
@@ -46,10 +63,9 @@ pub fn spawn_arena_bounds(commands: &mut Commands) {
 }
 
 pub fn spawn_castles(commands: &mut Commands) {
-    let arena = Vec3::from(ARENA_SIZE);
     let sprite = Sprite {
         custom_size: Some(Vec2::new(
-            arena.x,
+            ARENA_SIZE.width,
             CASTLE_WALL_THICKNESS,
         )),
         color: Color::GREEN,
@@ -59,7 +75,7 @@ pub fn spawn_castles(commands: &mut Commands) {
     // top
     commands
         .spawn_bundle(SpriteBundle {
-            transform: Transform::from_translation(Vec3::new(0.0, arena.y / 2.0, 0.0)),
+            transform: Transform::from_translation(Vec3::new(0.0, ARENA_SIZE.height_half, 0.0)),
             sprite: sprite.clone(),
             ..default()
         });
@@ -67,7 +83,7 @@ pub fn spawn_castles(commands: &mut Commands) {
     // bottom
     commands
         .spawn_bundle(SpriteBundle {
-            transform: Transform::from_translation(Vec3::new(0.0, -arena.y / 2.0, 0.0)),
+            transform: Transform::from_translation(Vec3::new(0.0, -ARENA_SIZE.height_half, 0.0)),
             sprite,
             ..default()
         });
@@ -76,7 +92,6 @@ pub fn spawn_castles(commands: &mut Commands) {
 pub fn spawn_castle_walls(
     commands: &mut Commands,
 ) {
-    let arena = Vec3::from(ARENA_SIZE);
     let sprite = Sprite {
         custom_size: Some(Vec2::new(
             CASTLE_WALL_LENGTH,
@@ -90,7 +105,7 @@ pub fn spawn_castle_walls(
     commands
         .spawn_bundle(SpriteBundle {
             transform: Transform::from_xyz(
-                -arena.x / 2.0 + CASTLE_WALL_LENGTH / 2.0,
+                -ARENA_SIZE.width_half + CASTLE_WALL_LENGTH_HALF,
                 -CASTLE_WALL_Y_TRANSLATION,
                 0.0
             ),
@@ -103,7 +118,7 @@ pub fn spawn_castle_walls(
     commands
         .spawn_bundle(SpriteBundle {
             transform: Transform::from_xyz(
-                arena.x / 2.0 - CASTLE_WALL_LENGTH / 2.0,
+                ARENA_SIZE.width_half - CASTLE_WALL_LENGTH_HALF,
                 -CASTLE_WALL_Y_TRANSLATION,
                 0.0
             ),
@@ -116,7 +131,7 @@ pub fn spawn_castle_walls(
     commands
         .spawn_bundle(SpriteBundle {
             transform: Transform::from_xyz(
-                -arena.x / 2.0 + CASTLE_WALL_LENGTH / 2.0,
+                -ARENA_SIZE.width_half + CASTLE_WALL_LENGTH_HALF,
                 CASTLE_WALL_Y_TRANSLATION,
                 0.0
             ),
@@ -129,7 +144,7 @@ pub fn spawn_castle_walls(
     commands
         .spawn_bundle(SpriteBundle {
             transform: Transform::from_xyz(
-                arena.x / 2.0 - CASTLE_WALL_LENGTH / 2.0,
+                ARENA_SIZE.width_half - CASTLE_WALL_LENGTH_HALF,
                 CASTLE_WALL_Y_TRANSLATION,
                 0.0
             ),

--- a/src/setup/player.rs
+++ b/src/setup/player.rs
@@ -2,7 +2,7 @@ use crate::prelude::*;
 
 const PLAYER_SPEED: f32 = 1200.0;
 const PLAYER_STARTING_TRANSLATION: (f32, f32, f32) =
-    (0.0, -SCREEN_HEIGHT / 2.0 + ARENA_WALL_THICKNESS + 10.0, 0.0);
+    (0.0, -SCREEN_SIZE.height_half + ARENA_WALL_THICKNESS + 10.0, 0.0);
 
 pub fn spawn_player(commands: &mut Commands) {
     commands

--- a/src/setup/ui/health_text.rs
+++ b/src/setup/ui/health_text.rs
@@ -7,7 +7,7 @@ pub fn spawn_health_text(commands: &mut Commands, asset_server: &Res<AssetServer
                 position_type: PositionType::Absolute,
                 position: Rect {
                     top: Val::Px(0.0),
-                    left: Val::Px(SCREEN_WIDTH / 2.0 + ARENA_SIZE.0 / 2.0 + 10.0),
+                    left: Val::Px(SCREEN_SIZE.width_half + ARENA_SIZE.width_half + 10.0),
                     ..default()
                 },
                 ..default()

--- a/src/setup/ui/main_menu.rs
+++ b/src/setup/ui/main_menu.rs
@@ -4,7 +4,19 @@ use crate::prelude::*;
 pub const BUTTON_COLOR_DEFAULT: Color = Color::rgb(0.15, 0.15, 0.15);
 pub const BUTTON_COLOR_HOVERED: Color = Color::rgb(0.25, 0.25, 0.25);
 
-const BUTTON_SIZE: (f32, f32) = (150.0, 65.0);
+pub struct ButtonSize {
+    pub width: f32,
+    pub width_half: f32,
+    pub height: f32,
+    pub height_half: f32,
+}
+
+pub const BUTTON_SIZE: ButtonSize = ButtonSize {
+    width: 150.0,
+    width_half: 75.0,
+    height: 65.0,
+    height_half: 65.0 / 2.0,
+};
 
 pub fn spawn_play_button(
     commands: &mut Commands,
@@ -57,10 +69,10 @@ fn get_button_bundle() -> ButtonBundle {
     ButtonBundle {
         // todo try to use flex instead of this manual calculation (NodeBundle as in GameOver text)
         style: Style {
-            size: Size::new(Val::Px(BUTTON_SIZE.0), Val::Px(BUTTON_SIZE.1)),
+            size: Size::new(Val::Px(BUTTON_SIZE.width), Val::Px(BUTTON_SIZE.height)),
             // center button
             position: Rect {
-                left: Val::Px(SCREEN_WIDTH / 2.0 - BUTTON_SIZE.0 / 2.0),
+                left: Val::Px(SCREEN_SIZE.width_half - BUTTON_SIZE.width_half),
                 right: Val::Auto,
                 top: Val::Percent(50.0),
                 bottom: Val::Auto

--- a/src/systems/player.rs
+++ b/src/systems/player.rs
@@ -1,14 +1,29 @@
 use crate::prelude::*;
 use bevy::input::mouse::MouseButtonInput;
 
-pub const PLAYER_SIZE: (f32, f32) = (24.0, 24.0);
+pub struct PlayerSize {
+    pub width: f32,
+    pub width_half: f32,
+    pub height: f32,
+    pub height_half: f32,
+}
+pub const PLAYER_SIZE: PlayerSize = PlayerSize {
+    width: 24.0,
+    width_half: 12.0,
+    height: 24.0,
+    height_half: 12.0,
+};
+impl From<PlayerSize> for Vec2 {
+    fn from(_: PlayerSize) -> Self {
+        Vec2::new(PLAYER_SIZE.width, PLAYER_SIZE.height)
+    }
+}
 
 pub fn player_movement_system(
     keyboard_input: Res<Input<KeyCode>>,
     mut query: Query<(&Player, &mut Transform)>,
 ) {
     for (player, mut transform) in query.iter_mut() {
-        let arena_size = Vec3::from(ARENA_SIZE);
         let mut movement = Vec2::new(0.0, 0.0);
         if keyboard_input.pressed(KeyCode::A) {
             movement.x -= 1.0;
@@ -28,17 +43,15 @@ pub fn player_movement_system(
         translation.y += MOVEMENT_TIME_STEP * movement.y * player.speed;
 
         // bound the player within the walls
-        let player_one_side_size = Vec2::from(PLAYER_SIZE).x / 2.0;
-
         translation.x = translation
             .x
-            .min(arena_size.x / 2.0 - player_one_side_size)
-            .max(-arena_size.x / 2.0 + player_one_side_size);
+            .min(ARENA_SIZE.width_half - PLAYER_SIZE.width_half)
+            .max(-ARENA_SIZE.width_half + PLAYER_SIZE.width_half);
 
         translation.y = translation
             .y
-            .min(-CASTLE_WALL_Y_TRANSLATION - ARENA_WALL_THICKNESS / 2.0 - player_one_side_size)
-            .max(-arena_size.y / 2.0 + CASTLE_WALL_THICKNESS / 2.0 + player_one_side_size);
+            .min(-CASTLE_WALL_Y_TRANSLATION - ARENA_WALL_THICKNESS_HALF - PLAYER_SIZE.width_half)
+            .max(-ARENA_SIZE.height_half + CASTLE_WALL_THICKNESS_HALF + PLAYER_SIZE.width_half);
     }
 }
 
@@ -61,7 +74,7 @@ pub fn player_shooting_system(
     for ev in evr_cursor.iter() {
         // cursor to world coordinates, since bevy does not yet have built-in function for this
         // (https://bevy-cheatbook.github.io/cookbook/cursor2world.html)
-        let cursor_world_pos = ev.position - Vec2::new(SCREEN_WIDTH, SCREEN_HEIGHT) / 2.0;
+        let cursor_world_pos = ev.position - Vec2::new(SCREEN_SIZE.width, SCREEN_SIZE.height) / 2.0;
         let cursor_world_pos: Vec3 = Vec3::new(cursor_world_pos.x, cursor_world_pos.y, 0.0);
         direction = cursor_world_pos - player_transform.translation;
     }

--- a/src/systems/spell.rs
+++ b/src/systems/spell.rs
@@ -15,8 +15,8 @@ pub fn spell_despawn_system(
 ) {
     for (entity, transform, sprite, _) in transformable_query.iter_mut() {
         let sprite_size = sprite.custom_size.expect("Sprite size must be set");
-        let despawn_top_y = SCREEN_HEIGHT / 2.0 - CASTLE_WALL_THICKNESS + sprite_size.y / 2.0;
-        let despawn_bottom_y = -SCREEN_HEIGHT / 2.0 + CASTLE_WALL_THICKNESS - sprite_size.y / 2.0;
+        let despawn_top_y = SCREEN_SIZE.height_half - CASTLE_WALL_THICKNESS + sprite_size.y / 2.0;
+        let despawn_bottom_y = -SCREEN_SIZE.height_half + CASTLE_WALL_THICKNESS - sprite_size.y / 2.0;
 
         if transform.translation.y >= despawn_top_y || transform.translation.y <= despawn_bottom_y
         {


### PR DESCRIPTION
Instead of dividing by 2 in size/position calculations (to adhere to bevy coordinate systems), use constants/structs that will already have these values calculated (parameters will have an additional counterpart `..._half` (e.g. `width` and `width_half`)). 