### PR TITLE
Add spell holding capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,10 @@ by slinging various spells and outsmarting their opponents
 
 <i>note: Players can only move inside their castles.</i>
 #### Player 1
-use `W A S D` keys to move and left mouse button to shoot
+- use `W A S D` keys to move
+- left mouse button to shoot.
+- Pressing and holding the right mouse button in the vicinity of spell will stop it,
+releasing the button will resume spell movement. 
 
 #### Player 2
 <i>note: Until multiplayer / AI is implemented this player can only move.</i>
@@ -24,6 +27,7 @@ use `Up, Left, Down, Right` keys to move
 - [x] Basic spell shooting (cooldown, bouncing against walls)
 - [x] Player health tracking and game over state
 - [x] UI (main menu and game over screen)
+- [x] Spell holding
 - [ ] AI for single player
 - [ ] Different kinds of spells
 - [ ] Mana system

--- a/src/components/spell.rs
+++ b/src/components/spell.rs
@@ -1,7 +1,19 @@
 use crate::prelude::*;
 
 #[derive(Component)]
-pub struct Spell;
+pub struct Spell {
+    pub is_on_hold: bool,
+    pub player: Player,
+}
+
+impl Spell {
+    pub fn new(player: Player) -> Self {
+        Spell {
+            is_on_hold: false,
+            player
+        }
+    }
+}
 
 #[derive(Bundle)]
 pub struct SpellBundle {

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,6 +59,7 @@ fn main() {
             SystemSet::on_update(AppState::InGame)
                 .with_system(player_movement_system) // this might need to be moved to fixedTimeStep
                 .with_system(player_shooting_system)
+                .with_system(spell_holding_system)
                 .with_system(spell_despawn_system)
                 .with_system(state_update_system)
                 .with_system(reduce_player_health_when_spell_goes_out_of_bounds)

--- a/src/setup/spell.rs
+++ b/src/setup/spell.rs
@@ -5,12 +5,17 @@ pub const SPELL_SIZE: (f32, f32) = (20.0, 20.0);
 const SPELL_VELOCITY: f32 = 500.0;
 const SPELL_STARTING_POSITION_OFFSET: (f32, f32, f32) = (0.0, 20.0, 0.0);
 
-pub fn spawn_spell(commands: &mut Commands, player_transform: &Transform, direction: Vec3) {
+pub fn spawn_spell(
+    commands: &mut Commands,
+    player_transform: &Transform,
+    direction: Vec3,
+    player: Player,
+) {
     let mut spell_starting_position = player_transform.translation;
     spell_starting_position += Vec3::from(SPELL_STARTING_POSITION_OFFSET);
 
     commands.spawn_bundle(SpellBundle {
-        spell: Spell,
+        spell: Spell::new(player),
         sprite: SpriteBundle {
             transform: Transform::from_translation(spell_starting_position),
             sprite: Sprite {

--- a/src/systems/player.rs
+++ b/src/systems/player.rs
@@ -132,44 +132,38 @@ fn handle_player_1_shooting(
     }
 }
 
+// RMB press holds the selected spell and release will shoot it in a new direction
 // todo update readme
-// todo if RMB is held, it should hold the spell once it comes into cursor's vicinity
 pub fn spell_holding_system(
-    mut evr_mouse_btn: EventReader<MouseButtonInput>,
+    mouse_button_input: Res<Input<MouseButton>>,
     mut evr_cursor: EventReader<CursorMoved>,
     mut spells_query: Query<(&mut Spell, &Sprite, &Transform)>,
 ) {
-    // RMB press holds the selected spell and release will shoot it in a new direction
-    for ev in evr_mouse_btn.iter() {
-        if ev.button != MouseButton::Right {
-            continue
+    // check if collision happens between spell and cursor vicinity
+    if mouse_button_input.pressed(MouseButton::Right) {
+        // todo use a radius
+        // todo detect closest instead of the first occurrence
+        for cursor in evr_cursor.iter() {
+            let cursor_world_pos = cursor.position - Vec2::new(SCREEN_SIZE.width_half, SCREEN_SIZE.height_half);
+            for (mut spell, sprite, transform) in spells_query.iter_mut() {
+                if collide(
+                    Vec3::from((cursor_world_pos, 0.0)),
+                    Vec2::from(CURSOR_VICINITY_FOR_SPELL_DETECTION),
+                    transform.translation,
+                    sprite.custom_size.expect("Sprite size must be set"),
+                ).is_some() {
+                    spell.is_on_hold = true;
+                };
+            }
         }
-        match ev.state.is_pressed() {
-            true => {
-                // for now just check if collision happens between spell and a cursor vicinity
-                // todo use a radius
-                // todo detect closest instead of the first occurrence
-                for cursor in evr_cursor.iter() {
-                    let cursor_world_pos = cursor.position - Vec2::new(SCREEN_SIZE.width_half, SCREEN_SIZE.height_half);
-                    for (mut spell, sprite, transform) in spells_query.iter_mut() {
-                        if collide(
-                            Vec3::from((cursor_world_pos, 0.0)),
-                            Vec2::from(CURSOR_VICINITY_FOR_SPELL_DETECTION),
-                            transform.translation,
-                            sprite.custom_size.expect("Sprite size must be set"),
-                        ).is_some() {
-                            spell.is_on_hold = true;
-                        };
-                    }
-                }
-            },
-            false => { // release the spell
-                // todo change trajectory
-                for (mut spell, _, _) in spells_query.iter_mut() {
-                    if spell.is_on_hold {
-                        spell.is_on_hold = false;
-                    }
-                }
+    }
+
+    // release the spell
+    if mouse_button_input.just_released(MouseButton::Right) {
+        // todo change trajectory
+        for (mut spell, _, _) in spells_query.iter_mut() {
+            if spell.is_on_hold {
+                spell.is_on_hold = false;
             }
         }
     }

--- a/src/systems/player.rs
+++ b/src/systems/player.rs
@@ -124,7 +124,7 @@ fn handle_player_1_shooting(
 
     for ev in evr_mouse_btn.iter() {
         if !ev.state.is_pressed() && ev.button == MouseButton::Left {
-            spawn_spell(commands, player_transform, direction);
+            spawn_spell(commands, player_transform, direction, Player::One);
             spell_cooldown.timer.reset();
         }
     }

--- a/src/systems/player.rs
+++ b/src/systems/player.rs
@@ -133,7 +133,6 @@ fn handle_player_1_shooting(
 }
 
 // RMB press holds the selected spell and release will shoot it in a new direction
-// todo update readme
 pub fn spell_holding_system(
     mouse_button_input: Res<Input<MouseButton>>,
     mut evr_cursor: EventReader<CursorMoved>,

--- a/src/systems/spell.rs
+++ b/src/systems/spell.rs
@@ -3,7 +3,10 @@ use crate::prelude::*;
 pub fn spell_movement_system(
     mut spell_query: Query<(&Spell, &Movement, &mut Transform)>
 ) {
-    for (_, movement, mut transform) in spell_query.iter_mut() {
+    for (spell, movement, mut transform) in spell_query.iter_mut() {
+        if spell.is_on_hold {
+            continue;
+        }
         transform.translation += movement.velocity * MOVEMENT_TIME_STEP;
     }
 }


### PR DESCRIPTION
- Add `is_on_hold` and `player` attributes to Spell
- On RMB press - hold the spell in cursor vicinity, on release - resume it's movement
- Update readme (instructions) with new mechanics